### PR TITLE
Fixes incorrect count for totalEventCount when the event hub contains empty partitions.

### DIFF
--- a/instructions/azure-events-messages/02-event-hubs-send-receive.md
+++ b/instructions/azure-events-messages/02-event-hubs-send-receive.md
@@ -222,7 +222,7 @@ In this section you add code to create the producer and consumer clients to send
     foreach (var partitionId in partitionIds)
     {
         PartitionProperties properties = await consumerClient.GetPartitionPropertiesAsync(partitionId);
-        if (properties.LastEnqueuedSequenceNumber >= properties.BeginningSequenceNumber)
+        if (!properties.IsEmpty && properties.LastEnqueuedSequenceNumber >= properties.BeginningSequenceNumber)
         {
             totalEventCount += (properties.LastEnqueuedSequenceNumber - properties.BeginningSequenceNumber + 1);
         }


### PR DESCRIPTION
# Module: Azure Events and Messaging
## Lab/Demo: 02 - Send and retrieve events from Azure Event Hubs

Fixes #70 

Changes proposed in this pull request:

- Use the `IsEmpty` partition property to determine if `totalEventcount` should be incremented.
- Increment only if the `IsEmpty` property is false.
