### PR TITLE
New workflow to sync remote instructions

### DIFF
--- a/.github/workflows/sync-remote-markdown.yml
+++ b/.github/workflows/sync-remote-markdown.yml
@@ -1,0 +1,102 @@
+name: Sync remote markdown
+
+on:
+  schedule:
+    # Daily at 06:00 UTC
+    - cron: '0 6 * * *'
+  # Allow manual runs
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+concurrency:
+  group: sync-remote-markdown
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download remote markdown files from list and strip front matter
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mkdir -p _includes
+
+          CONFIG_TXT="_includes/sources.txt"
+
+          urls=()
+
+          # Load from plain text file: one URL per non-empty, non-comment line
+          if [[ -f "$CONFIG_TXT" ]]; then
+            while IFS= read -r line; do
+              # trim leading/trailing whitespace (portable)
+              line="$(sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//' <<< "$line")"
+              [[ -z "$line" || "$line" =~ ^# ]] && continue
+              urls+=("$line")
+            done < "$CONFIG_TXT"
+          fi
+
+          if [[ ${#urls[@]} -eq 0 ]]; then
+            echo "No sources found. Add URLs to _includes/sources.txt or a YAML list in _includes/sources.yml."
+            exit 1
+          fi
+
+          echo "Found ${#urls[@]} source(s)."
+
+          download_and_process() {
+            local url="$1"
+
+            # Convert GitHub UI blob URLs to raw URLs if needed
+            if [[ "$url" =~ ^https://github.com/([^/]+)/([^/]+)/blob/([^/]+)/(.*)$ ]]; then
+              url="https://raw.githubusercontent.com/${BASH_REMATCH[1]}/${BASH_REMATCH[2]}/${BASH_REMATCH[3]}/${BASH_REMATCH[4]}"
+              base_name="$(basename "${BASH_REMATCH[4]}")"
+            else
+              base_name="$(basename "$url")"
+            fi
+
+            # Ensure it ends with .md for saving
+            if [[ ! "$base_name" =~ \.md$ ]]; then
+              base_name="${base_name}.md"
+            fi
+
+            tmp_file=$(mktemp)
+            out_file="_includes/${base_name}"
+
+            echo "Downloading: $url -> $out_file"
+            curl -fsSL "$url" -o "$tmp_file"
+
+            # Strip a single YAML front-matter block only if it is at the very top of the file
+            awk '
+              NR==1 && $0 ~ /^---[[:space:]]*$/ { infront=1; next }
+              infront && $0 ~ /^---[[:space:]]*$/ { infront=0; next }
+              infront { next }
+              { print }
+            ' "$tmp_file" > "$out_file"
+
+            rm -f "$tmp_file"
+          }
+
+          for u in "${urls[@]}"; do
+            download_and_process "$u"
+          done
+
+      - name: Commit and push if changes detected
+        run: |
+          git add _includes
+          if git diff --staged --quiet; then
+            echo "No changes to commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -m "chore: sync remote Markdown from sources list into _includes"
+          git push origin main

--- a/_includes/sources.txt
+++ b/_includes/sources.txt
@@ -1,0 +1,3 @@
+# One URL per line. Lines starting with # are ignored.
+# Example:
+https://github.com/MicrosoftLearning/mslearn-ai-vision/blob/main/Instructions/Labs/01-analyze-images.md


### PR DESCRIPTION
Instructions included in the GitHub pages may be sourced from remote repositories. This workflow will copy/sync a list of files on a daily basis so the local copies of the remotes are kept in sync with updates .

-
-
-