### PR TITLE
LAB: App service swap deployment slots - Added a note instructing users to configure storage for Cloud Shell

### DIFF
--- a/instructions/azure-app-service/02-app-service-deployment-slots.md
+++ b/instructions/azure-app-service/02-app-service-deployment-slots.md
@@ -28,6 +28,8 @@ In this section you download the sample app and set variables to make the comman
 
     > **Note**: If you have previously created a cloud shell that uses a *PowerShell* environment, switch it to ***Bash***.
 
+    > **Note**: If the portal asks you to select a storage to persist your files, choose **No storage account required**, select the subscription you are using and press **Apply**.
+
 1. In the cloud shell toolbar, in the **Settings** menu, select **Go to Classic version** (this is required to use the code editor).
 
 1. Run the following **git** command to clone the sample app repository.

--- a/instructions/azure-app-service/02-app-service-deployment-slots.md
+++ b/instructions/azure-app-service/02-app-service-deployment-slots.md
@@ -103,7 +103,7 @@ In this section you create a deployment slot, modify the HTML in the app, and de
 
 ## Swap the staging and production slots
 
-You can perform a swap in the Azure portal with the **Swap** option in the toolbar. The **Swap** option will appear in the toolbar if you select **Overview** or **Deployment > Deployment slots** in the left menu.
+You can perform a swap in the Azure portal with the **Swap** option in the toolbar. The **Swap** option will appear in the toolbar if you select **Overview** or **Deployment > Deployment slots** in the left menu of your web app.
 
 1. In the Azure portal, select **Swap** in the toolbar to open the **Swap** panel.
 

--- a/instructions/azure-app-service/02-app-service-deployment-slots.md
+++ b/instructions/azure-app-service/02-app-service-deployment-slots.md
@@ -47,7 +47,7 @@ In this section you download the sample app and set variables to make the comman
     echo $appName
     ```
 
-1. Navigate to the directory that contains the sample code and run the **az webapp up** command. **Note:** This command might take a few minutes to run.
+1. Navigate to the directory that contains the sample code and run the **az webapp up** command. 
 
     ```bash
     cd html-docs-hello-world
@@ -56,6 +56,8 @@ In this section you download the sample app and set variables to make the comman
     ```
 
     Now that your deployment has finished it's time to view the web app.
+
+    > **Note:** This command might take a few minutes to run.
 
 1. In the Azure portal navigate to the web app you deployed. You can enter the name you noted earlier in the **Search resources, services, and docs (G + /)** search bar, and select the resource from the list.
 


### PR DESCRIPTION
# Module: 01
## Lab/Demo: 02 - Swap deployment slots in Azure App Service

Changes proposed in this pull request:

This pull request updates the deployment slot instructions for Azure App Service to improve clarity and provide additional guidance for users. The most important changes are grouped below:

User guidance improvements:

* Added a note instructing users to select "No storage account required" if prompted to persist files in the portal, clarifying the storage selection step.
* Moved the note about the `az webapp up` command possibly taking a few minutes to a more visible location after the command is run, making it easier for users to notice. [[1]](diffhunk://#diff-c191228f70352001464857264e6a413521caa0e3ab9193f0eeb1904dcef98680L48-R50) [[2]](diffhunk://#diff-c191228f70352001464857264e6a413521caa0e3ab9193f0eeb1904dcef98680R60-R61)

Clarification of portal navigation:

* Clarified that the "Swap" option appears in the toolbar when selecting "Overview" or "Deployment > Deployment slots" in the left menu of the web app, making navigation instructions more precise.