### PR TITLE
Correct command syntax for az appconfig create

### DIFF
--- a/instructions/azure-secure-solutions/02-app-config-retrieve.md
+++ b/instructions/azure-secure-solutions/02-app-config-retrieve.md
@@ -67,7 +67,7 @@ In this section of the exercise you create the needed resources in Azure with th
     ```
     az appconfig create --location $location \
         --name $appConfigName \
-        --resource-group $resourceGroup
+        --resource-group $resourceGroup \
         --sku Free
     ```
 


### PR DESCRIPTION
Fixed command formatting for creating AppConfig resource.

# Module: 07
## Lab/Demo: 02

Fixes #107 .

Changes proposed in this pull request:

- Added trailing backslash to multi-line AZ CLI command