### PR TITLE
Fix container registry name to be lowercase

### DIFF
--- a/instructions/azure-container-services/01-container-image-acr-tasks.md
+++ b/instructions/azure-container-services/01-container-image-acr-tasks.md
@@ -36,7 +36,7 @@ This exercise takes approximately **20** minutes to complete.
 
     ```bash
     az acr create --resource-group myResourceGroup \
-        --name myContainerRegistry --sku Basic
+        --name mycontainerregistry --sku Basic
     ```
 
     > **Note:** The command creates a *Basic* registry, a cost-optimized option for developers learning about Azure Container Registry.


### PR DESCRIPTION
Updated the container registry name to be lowercase.

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-the current code gives the following error, 'argument error: Registry name must use only lowercase.'
-the updated code gets rid of the error.